### PR TITLE
Deploy fix for scoreboard length

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
         "description": "Optional Bedrock resource pack to extend Geyser functionality",
         "name": "GeyserOptionalPack",
         "uuid": "e5f5c938-a701-11eb-b2a3-047d7bb283ba",
-        "version": [1, 0, 6],
+        "version": [1, 0, 7],
         "min_engine_version": [ 1, 16, 0 ]
     },
     "modules": [
@@ -12,7 +12,7 @@
             "description": "GeyserOptionalPack",
             "type": "resources",
             "uuid": "eebb4ea8-a701-11eb-95ba-047d7bb283ba",
-            "version": [1, 0, 6]
+            "version": [1, 0, 7]
         }
     ]
 }

--- a/ui/scoreboards.json
+++ b/ui/scoreboards.json
@@ -1,0 +1,26 @@
+{
+	"namespace": "scoreboard",
+    "scoreboard_sidebar_player": {
+        "type": "label",
+        "layer": 2,
+        "text": "#player_name_sidebar",
+        "size": [
+            "default",
+            10
+        ],
+        "max_size": [
+            250,
+            10
+        ],
+        "font_scale_factor": 1.0,
+        "locked_alpha": 1.0,
+        "color": "$player_name_color",
+        "bindings": [
+            {
+                "binding_name": "#player_name_sidebar",
+                "binding_type": "collection",
+                "binding_collection_name": "scoreboard_players"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This adds a way bigger **max** size to the scoreboard to allow the placeholders to show up if they're too big, here is how it looks like on my server (ignore the transparent scoreboard, that's not included in this PR)

![image](https://github.com/GeyserMC/GeyserOptionalPack/assets/33335971/f944928f-08be-420d-964e-66fc8217b032)

![image](https://github.com/GeyserMC/GeyserOptionalPack/assets/33335971/2296a620-5d85-41ff-b980-c5cf453a9de3)
