### PR TITLE
Feature: Client side UI changes to remove Bedrock-only fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Download: https://ci.opencollab.dev/job/GeyserMC/job/GeyserOptionalPack/job/mast
 - Shulker invisibility parity
 - Spectral arrow entity texture
 - Bypass for the scoreboard character limit
+- Hides UI elements that do not exist on Java edition, such as:
+  - Text input field in the cartography table
+  - 2x2 crafting grid while in creative mode
+  - Tick-delay and rename fields in the command block menu
 
 ### Manually building
 

--- a/developer_documentation.md
+++ b/developer_documentation.md
@@ -14,6 +14,7 @@
    * [Spectral arrow entities](#Spectral-arrow-entities)
    * [Spyglass animations](#Spyglass-animations)
    * [Zombie villager textures](#Zombie-villager-textures)
+   * [UI modifications](#ui-modifications)
 <!--te-->
 
 ### Introduction
@@ -268,3 +269,45 @@ Unfortunately, the spyglass cannot actually be used in the offhand by Bedrock pl
 
 Like villagers, zombie villagers in Java Edition have visible biome and profession variants. It appears that initial implementation of this was started in the Bedrock vanilla resources, given the presence of the entity with the identifier `minecraft:zombie_villager_v2`. However, the textures specified in this vanilla entity definition appear to be entirely blank TGA files. Luckily, the profession textures of zombie villagers and villagers are essentially identical, so the entity definition was updated to reference the villager profession textures. 
 Zombie villagers, like villagers, have a profession level. This is implemented by adding the same vanilla render controller used to create this effect in the villager entity, `controller.render.villager_v2_level`. The remainder of the entity definition is unchanged.
+
+### UI modifications
+Some inventories have added functionality on Bedrock, that does not exist on Java edition. For example, this includes:
+- 2x2 crafting grid while in creative mode
+- An option to rename maps in the cartography table
+- Command block renaming or enabling/setting command block execution delays
+
+To resolve this issue, this pack uses Json UI modification on these inventories. Here's how:
+
+`cartography_screen.json`
+```json
+{
+  "text_box_panel": {
+    "ignored": true
+  }
+}
+```
+
+This hides the renaming field in the cartography table that cannot be used. This does not modify the textures or functionality, 
+and just the visual appearance for Bedrock players.
+
+Hiding the 2x2 crafting grid is a bit more involved, and that uses bindings to only conditionally hide the 2x2 grid when we are in creative mode:
+`inventory_screen.json`
+```json
+{
+  "crafting_panel_2x2": {
+    "modifications": [
+      {
+        "array_name": "bindings",
+        "operation": "insert_front",
+        "value": {
+          "binding_name": "(not #is_creative_mode)",
+          "binding_name_override": "#visible"
+        }
+      }
+    ]
+  }
+}
+```
+
+This uses the `#is_creative_mode` binding, and applies it to the crafting panel. Note that we insert this modification 
+instead of directly modifying the UI - this allows the GeyserOptionalPack to stay compatible with other resource packs that modify the UI.

--- a/developer_documentation.md
+++ b/developer_documentation.md
@@ -276,7 +276,7 @@ Some inventories have added functionality on Bedrock, that does not exist on Jav
 - An option to rename maps in the cartography table
 - Command block renaming or enabling/setting command block execution delays
 
-To resolve this issue, this pack uses Json UI modification on these inventories. Here's how:
+To resolve this issue, this pack uses Json UI modification on these inventory UIs. Here's how:
 
 `cartography_screen.json`
 ```json
@@ -288,9 +288,9 @@ To resolve this issue, this pack uses Json UI modification on these inventories.
 ```
 
 This hides the renaming field in the cartography table that cannot be used. This does not modify the textures or functionality, 
-and just the visual appearance for Bedrock players.
+but instead just alters the visual appearance for Bedrock players.
 
-Hiding the 2x2 crafting grid is a bit more involved, and that uses bindings to only conditionally hide the 2x2 grid when we are in creative mode:
+Hiding the 2x2 crafting grid is a bit more involved. We have to use bindings to only conditionally hide the 2x2 grid when we are in creative mode:
 `inventory_screen.json`
 ```json
 {
@@ -309,5 +309,5 @@ Hiding the 2x2 crafting grid is a bit more involved, and that uses bindings to o
 }
 ```
 
-This uses the `#is_creative_mode` binding, and applies it to the crafting panel. Note that we insert this modification 
-instead of directly modifying the UI - this allows the GeyserOptionalPack to stay compatible with other resource packs that modify the UI.
+This uses the `#is_creative_mode` binding, and applies it to the crafting panel. Note that we insert this modification into the bindings array
+instead of directly modifying the UI - this allows the GeyserOptionalPack to stay compatible with other resource packs that modify this screen.

--- a/ui/cartography_screen.json
+++ b/ui/cartography_screen.json
@@ -1,0 +1,5 @@
+{
+  "text_box_panel": {
+    "ignored": true
+  }
+}

--- a/ui/command_block_screen.json
+++ b/ui/command_block_screen.json
@@ -1,0 +1,23 @@
+{
+  "left_scroll_panel_content/content_stack_panel/offset2": {
+    "ignored": true
+  },
+  "left_scroll_panel_content/content_stack_panel/offset_execute_on_first_tick": {
+    "ignored": true
+  },
+  "left_scroll_panel_content/content_stack_panel/option_label_execute_on_first_tick": {
+    "ignored": true
+  },
+  "left_scroll_panel_content/content_stack_panel/execute_on_first_tick_toggle": {
+    "ignored": true
+  },
+  "left_scroll_panel_content/content_stack_panel/offset_tick_delay": {
+    "ignored": true
+  },
+  "left_scroll_panel_content/content_stack_panel/option_label_tick_delay": {
+    "ignored": true
+  },
+  "left_scroll_panel_content/content_stack_panel/tick_delay_text": {
+    "ignored": true
+  }
+}

--- a/ui/inventory_screen.json
+++ b/ui/inventory_screen.json
@@ -1,0 +1,14 @@
+{
+  "crafting_panel_2x2": {
+    "modifications": [
+      {
+        "array_name": "bindings",
+        "operation": "insert_front",
+        "value": {
+          "binding_name": "(not #is_creative_mode)",
+          "binding_name_override": "#visible"
+        }
+      }
+    ]
+  }
+}

--- a/ui/inventory_screen_pocket.json
+++ b/ui/inventory_screen_pocket.json
@@ -1,0 +1,14 @@
+{
+  "survival_panel_pocket": {
+    "modifications": [
+      {
+        "array_name": "bindings",
+        "operation": "insert_front",
+        "value": {
+          "binding_name": "(not #is_creative_mode)",
+          "binding_name_override": "#visible"
+        }
+      }
+    ]
+  }
+}

--- a/ui/scoreboards.json
+++ b/ui/scoreboards.json
@@ -1,26 +1,5 @@
 {
-	"namespace": "scoreboard",
     "scoreboard_sidebar_player": {
-        "type": "label",
-        "layer": 2,
-        "text": "#player_name_sidebar",
-        "size": [
-            "default",
-            10
-        ],
-        "max_size": [
-            250,
-            10
-        ],
-        "font_scale_factor": 1.0,
-        "locked_alpha": 1.0,
-        "color": "$player_name_color",
-        "bindings": [
-            {
-                "binding_name": "#player_name_sidebar",
-                "binding_type": "collection",
-                "binding_collection_name": "scoreboard_players"
-            }
-        ]
+        "max_size": [ 250, 10 ]
     }
 }


### PR DESCRIPTION
Changes made:
- Cleaned up the scoreboard length fix to only modify what is necessary (thanks tyepavitt)

- Removed the field to rename the command block & execute delay fields since these do not exist on Java edition.

|BEFORE|AFTER|
|--|--|
|<img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/5c9bd7f4-9821-4dd6-9a60-708cc835ae65" width = "250"/> | <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/3c8f24f9-63b9-483a-86f8-aa51c0de350a" width="250" /> |

- Removed the renaming field on the cartography table, since that also does not exist on Java edition.

|BEFORE|AFTER|
|--|--|
|<img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/a5715474-7575-47af-ba50-1097a4a673f4" width = "250"/> | <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/a3971b1d-58a5-4f7f-bff2-eae7757c9820" width="250"/> |

- Removed the 2x2 crafting grid in the creative mode inventory. This does not exist on Java edition.

| | Pocket UI | Classic UI |
|----------|------------|-----------|
| BEFORE | <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/a9087293-f1b1-4316-b4a9-dfdcee73af33" width="250" /> | <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/eec7066e-fafc-42e2-b6eb-7a0011778205" width="250" /> |
| AFTER |  <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/9bf28538-b2b1-4e04-83f3-11fbca03345c" width="250" /> |  <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/eab5cb93-280c-4bfd-9fea-383a6a19fd49" width="250" /> |
