### PR TITLE
Feature: Structure block UI/texture change

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Download: [GeyserOptionalPack.mcpack](https://download.geysermc.org/v2/projects/
   - Text input field in the cartography table
   - 2x2 crafting grid while in creative mode
   - Tick-delay and rename fields in the command block menu
+  - Structure block options that do not exist on Java
 
 ### Manually building
 

--- a/developer_documentation.md
+++ b/developer_documentation.md
@@ -270,13 +270,18 @@ Unfortunately, the spyglass cannot actually be used in the offhand by Bedrock pl
 Like villagers, zombie villagers in Java Edition have visible biome and profession variants. It appears that initial implementation of this was started in the Bedrock vanilla resources, given the presence of the entity with the identifier `minecraft:zombie_villager_v2`. However, the textures specified in this vanilla entity definition appear to be entirely blank TGA files. Luckily, the profession textures of zombie villagers and villagers are essentially identical, so the entity definition was updated to reference the villager profession textures. 
 Zombie villagers, like villagers, have a profession level. This is implemented by adding the same vanilla render controller used to create this effect in the villager entity, `controller.render.villager_v2_level`. The remainder of the entity definition is unchanged.
 
+### Structure block texture changes
+Bedrock edition is currently wrongly assigning textures to the load, save and corner structure block modes. The `terrain_texture.json` file fixes this by
+putting the textures in the correct order. See https://bugs.mojang.com/browse/MCPE-48224 for the associated bug report.
+
 ### UI modifications
 Some inventories have added functionality on Bedrock, that does not exist on Java edition. For example, this includes:
 - 2x2 crafting grid while in creative mode
 - An option to rename maps in the cartography table
 - Command block renaming or enabling/setting command block execution delays
+- Structure block options such as load animations, ability to remove all blocks in selected area, and others.
 
-To resolve this issue, this pack uses Json UI modification on these inventory UIs. Here's how:
+To resolve these issues, this pack uses Json UI modification on these inventory UIs. Here's how:
 
 `cartography_screen.json`
 ```json

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
         "description": "Optional Bedrock resource pack to extend Geyser functionality",
         "name": "GeyserOptionalPack",
         "uuid": "e5f5c938-a701-11eb-b2a3-047d7bb283ba",
-        "version": [1, 0, 8],
+        "version": [1, 0, 9],
         "min_engine_version": [ 1, 16, 0 ]
     },
     "modules": [
@@ -12,7 +12,7 @@
             "description": "GeyserOptionalPack",
             "type": "resources",
             "uuid": "eebb4ea8-a701-11eb-95ba-047d7bb283ba",
-            "version": [1, 0, 8]
+            "version": [1, 0, 9]
         }
     ]
 }

--- a/textures/terrain_texture.json
+++ b/textures/terrain_texture.json
@@ -1,0 +1,16 @@
+{
+  "resource_pack_name": "geyseroptionalpack",
+  "texture_name": "atlas.terrain",
+  "texture_data": {
+    "structure_block": {
+      "textures": [
+        "textures/blocks/structure_block",
+        "textures/blocks/structure_block_save",
+        "textures/blocks/structure_block_load",
+        "textures/blocks/structure_block_corner",
+        "textures/blocks/structure_block_data",
+        "textures/blocks/structure_block_export"
+      ]
+    }
+  }
+}

--- a/ui/structure_editor_screen.json
+++ b/ui/structure_editor_screen.json
@@ -11,15 +11,6 @@
     "load_mode_panel/remove_blocks": {
         "ignored": true
     },
-    "load_mode_panel/mirror_label": {
-        "ignored": true
-    },
-    "load_mode_panel/mirror_checkboxes_centerer": {
-        "ignored": true
-    },
-    "load_mode_panel/checkbox_offset": {
-        "ignored": true
-    },
     "load_mode_panel/animation_mode": {
         "ignored": true
     },

--- a/ui/structure_editor_screen.json
+++ b/ui/structure_editor_screen.json
@@ -1,0 +1,62 @@
+{
+    "load_mode_panel/remove_blocks_offset": {
+        "ignored": true
+    },
+    "load_mode_panel/waterlog_blocks": {
+        "ignored": true
+    },
+    "load_mode_panel/waterlog_blocks_offset": {
+        "ignored": true
+    },
+    "load_mode_panel/remove_blocks": {
+        "ignored": true
+    },
+    "load_mode_panel/mirror_label": {
+        "ignored": true
+    },
+    "load_mode_panel/mirror_checkboxes_centerer": {
+        "ignored": true
+    },
+    "load_mode_panel/checkbox_offset": {
+        "ignored": true
+    },
+    "load_mode_panel/animation_mode": {
+        "ignored": true
+    },
+    "load_mode_panel/animation_time_label": {
+        "ignored": true
+    },
+    "load_mode_panel/animation_time_field": {
+        "ignored": true
+    },
+
+    "save_mode_panel/remove_blocks_offset": {
+        "ignored": true
+    },
+    "save_mode_panel/remove_blocks": {
+        "ignored": true
+    },
+    "save_mode_panel/redstone_save_offset": {
+        "ignored": true
+    },
+    "save_mode_panel/redstone_save_mode": {
+        "ignored": true
+    },
+
+    "button_panel_wrapper/panel/save_panel": {
+        "ignored": true
+    },
+    "button_panel_wrapper/panel/save_panel_no_export": {
+        "ignored": false
+    },
+    "button_panel_wrapper/panel/load_panel": {
+        "ignored": true
+    },
+    "button_panel_wrapper/panel/load_panel_no_export": {
+        "ignored": false
+    },
+
+    "mode_dropdown_content": {
+        "$3DExport_support": false
+    }
+}   


### PR DESCRIPTION
These changes should bring the structure block UI more in line with the Java structure block's features.

Before:

| save panel | load panel | block textures (save, corner, load)
|-------|-----------|-------|
| <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/66ae873a-b06e-43aa-8d60-97a8c52becb3" width = "300"/> <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/6a528444-cf3c-4689-ada2-ef7e087fd96f" width = "300"/> | <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/18367404-de81-4aff-b048-b851effb76c7" width = "300"/>  <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/c118b6d8-9fe7-458b-911b-88add1b35cac" width = "300"/> |<img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/5cce347f-ba5e-49f6-b076-114e4d750db9" width = "300"/>|

After:

| save panel | load panel | block textures (save, corner, load)
|-------|-----------|-------|
| <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/8948c28f-6116-4550-910c-15a860b9d4e9" width = "300"/> | <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/568aadae-8605-41ee-bc80-89b25a2a044f" width = "300"/> <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/9b16e58a-d6b6-4693-81bd-3bb67d00bc5c" width = "300"/> | <img src="https://github.com/GeyserMC/GeyserOptionalPack/assets/105284508/a953d958-70f6-4bf2-8922-e389a5be6bb4" width = "300"/> |

Essentially:
- removed 3d_export option, or exporting/importing from storage 
- ~~removed mirroring options when loading structures in - they work differently on java vs bedrock~~ supported now
- removed various other fields that don't exist on Java.



