### PR TITLE
Add ImageMagick back to container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
         # See https://github.com/actions/checkout/commits
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
+      - name: Install imagemagick
+        run: apt install imagemagick
+
       - name: Prepare pack
         run: bash prepare_pack.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
         # See https://github.com/actions/checkout/commits
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - name: Install imagemagick
-        run: apt install imagemagick
+      - name: Install ImageMagick
+        run: sudo apt install -y imagemagick
 
       - name: Prepare pack
         run: bash prepare_pack.sh


### PR DESCRIPTION
Fixes https://github.com/GeyserMC/GeyserOptionalPack/issues/62
This happened because the Ubuntu 24 LTS actions runner no longer contains ImageMagick 